### PR TITLE
Fix keeping session in update_krs

### DIFF
--- a/backend/organizations/management/commands/update_krs.py
+++ b/backend/organizations/management/commands/update_krs.py
@@ -11,7 +11,7 @@ class Command(BaseCommand):
          :return: tuple of list of objects and next url
          :rtype: (list, (str|None))
         """
-        session = session and requests.Session()
+        session = session or requests.Session()
         if url is None:
             req = session.get(URL, params={
                 'conditions[krs_podmioty.forma_prawna_typ_id]': '2',


### PR DESCRIPTION
Hej,

Jeżeli intencją autora kodu było uczynienie opcjonalnym podanie sesji to nie udało mu się to zważywszy na sposób działania operatorów logicznych w Pythonie.

Spójrzy na zestawienie działania ich:

```
In [1]: %cpaste
Pasting code; enter '--' alone on the line to stop or use Ctrl-D.
:def test(r):
    print ("A")
    return r
:::
:<EOF>
In [3]: print test(1) or test(2)
A
1

In [4]: print test(None) or test(2)
A
A
2

In [5]: print test(1) or test(None)
A
1

In [6]: print test(1) and test(2)
A
A
2

In [7]: print test(None) and test(2)
A
None

In [8]: print test(1) and test(None)
A
A
None
```

Jak porównamy przypadek z pierwszym None tj. przypadek [4] i [7] widzimy wyraźnie, że w wyniku otrzymamy niedopuszczalne wartości.

Z poważaniem, 
